### PR TITLE
Remove vpc_id from aws.sample.tf in state_file sections

### DIFF
--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -87,7 +87,6 @@ module "control-nodes" {
   # uncomment below it you want to use remote state for vpc variables
   #availability_zones = "${terraform_remote_state.vpc.output.availability_zones}"
   #security_group_ids = "${terraform_remote_state.vpc.output.default_security_group},${module.security-groups.ui_security_group},${module.security-groups.control_security_group}"
-  #vpc_id = "${terraform_remote_state.vpc.output.vpc_id}"
   #vpc_subnet_ids = "${terraform_remote_state.vpc.output.subnet_ids}"
 }
 
@@ -107,7 +106,6 @@ module "edge-nodes" {
   # uncomment below it you want to use remote state for vpc variables
   #availability_zones = "${terraform_remote_state.vpc.output.availability_zones}"
   #security_group_ids = "${terraform_remote_state.vpc.output.default_security_group},${module.security-groups.edge_security_group}"
-  #vpc_id = "${terraform_remote_state.vpc.output.vpc_id}"
   #vpc_subnet_ids = "${terraform_remote_state.vpc.output.subnet_ids}"
 }
 
@@ -129,7 +127,6 @@ module "worker-nodes" {
   # uncomment below it you want to use remote state for vpc variables
   #availability_zones = "${terraform_remote_state.vpc.output.availability_zones}"
   #security_group_ids = "${terraform_remote_state.vpc.output.default_security_group},${module.security-groups.worker_security_group}"
-  #vpc_id = "${terraform_remote_state.vpc.output.vpc_id}"
   #vpc_subnet_ids = "${terraform_remote_state.vpc.output.subnet_ids}"
 }
 
@@ -151,7 +148,6 @@ module "kubeworker-nodes" {
   # uncomment below it you want to use remote state for vpc variables
   #availability_zones = "${terraform_remote_state.vpc.output.availability_zones}"
   #security_group_ids = "${terraform_remote_state.vpc.output.default_security_group},${module.security-groups.worker_security_group}"
-  #vpc_id = "${terraform_remote_state.vpc.output.vpc_id}"
   #vpc_subnet_ids = "${terraform_remote_state.vpc.output.subnet_ids}"
 }
 


### PR DESCRIPTION
Git version: v1.0.3

`vpc_id` was removed from the `aws.sample.tf` and from the `terraform/aws/instance/main.tf` in https://github.com/CiscoCloud/mantl/commit/cae257257782b8e3cadd55b35276557f9f98f9f1#diff-e3a3c1dab01c11733dd82f3a01df46e7

This was not removed from the commented out sections for using remote state. If this was an accident, the attached PR resolves the issue.
